### PR TITLE
feat: add new off method

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,41 @@ emitter.emit('event-id', { x: 0, y: 0 })
 
 ### .on()
 
-Registers a specific event.
+Registers an event listener for a specific event type.
+
+Returns a cleanup function that removes the listener when called.
 
 ```ts
-emitter.on(id: string, callback: (event: any) => void)
+emitter.on<K>(id: K, callback: (event: Events[K]) => void): () => void
+```
+
+```ts
+// Adds click listener
+const unsubscribe = emitter.on('scroll', ({ x, y }) => {
+  console.log(x, y)
+})
+
+// Removes the listener
+unsubscribe()
+```
+
+### .off()
+
+Removes event listeners.
+
+```ts
+emitter.off<K>(id?: K | undefined, callback?: ((event: Events[K]) => void) | undefined): void
+```
+
+```ts
+// Removes all event listeners across all event types
+emitter.off()
+
+// Removes all click listeners
+emitter.off('click')
+
+// Removes specific scroll callback
+emitter.off('scroll', scrollCallback)
 ```
 
 ### .emit()
@@ -70,7 +101,15 @@ emitter.on(id: string, callback: (event: any) => void)
 Emits a specific event.
 
 ```ts
-emitter.emit(id: string, event: any)
+emitter.emit<K>(id: K, event?: Events[K] | undefined): void
+```
+
+```ts
+// Emits scroll event with position data
+emitter.emit('scroll', { x: window.scrollX, y: window.scrollY })
+
+// Emits event without second parameter
+emitter.emit('eventWithoutData')
 ```
 
 ### .events
@@ -88,7 +127,7 @@ emitter.events
 Checks if a specific event by `id` exists in the map.
 
 ```ts
-emitter.events.has(id: string)
+emitter.events.has(id: string | symbol)
 ```
 
 ### .get()
@@ -96,7 +135,7 @@ emitter.events.has(id: string)
 Gets a specific event by `id` from the map.
 
 ```ts
-emitter.events.get(id: string)
+emitter.events.get(id: string | symbol)
 ```
 
 ### .delete()
@@ -104,7 +143,7 @@ emitter.events.get(id: string)
 Deletes a specific event by `id` from the map.
 
 ```ts
-emitter.events.delete(id: string)
+emitter.events.delete(id: string | symbol)
 ```
 
 ### .clear()

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -2,22 +2,21 @@ import { createEmitter } from '../../src'
 import type { Emitter } from '../../src/types'
 
 type Events = {
-  'event-id': { x: number; y: number }
+  'event-1': { x: number; y: number }
+  'event-2': { z: number }
   // ...
 }
 
 const emitter: Emitter<Events> = createEmitter<Events>()
 
-emitter.on('event-id', (e) => console.log(e.x, e.y)) // 0 0
+emitter.on('event-1', (e) => console.log('emitter.on', e.x, e.y)) // 0 0
 
-emitter.emit('event-id', { x: 0, y: 0 })
+emitter.emit('event-1', { x: 0, y: 0 })
 
-console.log(emitter.events) // Map(1) {'event-id' => Array(1)}
+const eventId = emitter.events.get('event-1')
 
-const eventId = emitter.events.get('event-id')
+console.log('emitter.get', eventId) // [0]: (e) => console.log("emitter.on", e.x, e.y)
 
-console.log(eventId) // (e) => console.log(e.x, e.y)
+emitter.off()
 
-if (emitter.events.has('event-id')) emitter.events.delete('event-id')
-
-console.log(emitter.events) // Map(0) {size: 0}
+console.log('emitter.events', emitter.events) // Map(0) {size: 0}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { EventsMap, Emitter } from './types'
  * @example
  *
  * ```ts
- * import { createEmitter, Emitter } from '@hypernym/emitter'
+ * import { createEmitter, type Emitter } from '@hypernym/emitter'
  *
  * type Events = {
  *   'event-id': { x: number; y: number }
@@ -21,21 +21,45 @@ import type { EventsMap, Emitter } from './types'
  * ```
  */
 export function createEmitter<Events extends EventsMap>(): Emitter<Events> {
-  const events = new Map<keyof Events, Array<(event: any) => void>>()
+  const events = new Map<
+    keyof Events,
+    ((event: Events[keyof Events]) => void)[]
+  >()
 
   return {
     events,
-
     on<K extends keyof Events>(
       id: K,
       callback: (event: Events[K]) => void,
-    ): void {
-      if (events.has(id)) events.get(id)?.push(callback)
-      else events.set(id, [callback])
+    ): () => void {
+      if (events.has(id)) events.get(id)?.push(callback as any)
+      else events.set(id, [callback as any])
+      return () => this.off(id, callback)
     },
-
+    off<K extends keyof Events>(
+      id?: K,
+      callback?: (event: Events[K]) => void,
+    ): void {
+      if (!id) {
+        events.clear()
+        return
+      }
+      if (!callback) {
+        events.delete(id)
+        return
+      }
+      const callbacks = events.get(id)
+      if (callbacks) {
+        const filtered = callbacks.filter((cb) => cb !== callback)
+        if (filtered.length) events.set(id, filtered)
+        else events.delete(id)
+      }
+    },
     emit<K extends keyof Events>(id: K, event: Events[K]): void {
-      events.get(id)?.forEach((callback) => callback(event))
+      events
+        .get(id)
+        ?.slice()
+        .forEach((cb) => cb(event))
     },
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export interface EventsMap {
-  [id: string]: unknown
+  [id: string | symbol]: unknown
 }
 
 export interface Emitter<Events extends EventsMap> {
@@ -14,27 +14,62 @@ export interface Emitter<Events extends EventsMap> {
    * emitter.events
    * ```
    */
-  events: Map<keyof Events, Array<(event: any) => void>>
+  events: Map<keyof Events, ((event: Events[keyof Events]) => void)[]>
   /**
-   * Registers a specific event.
+   * Registers an event listener for a specific event type.
+   *
+   * Returns a cleanup function that removes the listener when called.
    *
    * @example
    *
    * ```ts
-   * emitter.on('event-id', e => console.log(e.x, e.y))
+   * // Adds click listener
+   * const unsubscribe = emitter.on('scroll', ({ x, y }) => {
+   *   console.log(x, y)
+   * })
+   *
+   * // Removes the listener
+   * unsubscribe()
    * ```
    */
-  on<K extends keyof Events>(id: K, callback: (event: Events[K]) => void): void
+  on<K extends keyof Events>(
+    id: K,
+    callback: (event: Events[K]) => void,
+  ): () => void
+  /**
+   * Removes event listeners.
+   *
+   * @example
+   *
+   * ```ts
+   * // Removes all event listeners across all event types
+   * emitter.off()
+   *
+   * // Removes all click listeners
+   * emitter.off('click')
+   *
+   * // Removes specific scroll callback
+   * emitter.off('scroll', scrollCallback)
+   * ```
+   */
+  off<K extends keyof Events>(
+    id?: K,
+    callback?: (event: Events[K]) => void,
+  ): void
   /**
    * Emits a specific event.
    *
    * @example
    *
    * ```ts
-   * emitter.emit('event-id', { x: 0, y: 0 })
+   * // Emits scroll event with position data
+   * emitter.emit('scroll', { x: window.scrollX, y: window.scrollY })
+   *
+   * // Emits event without second parameter
+   * emitter.emit('eventWithoutData')
    * ```
    */
-  emit<K extends keyof Events>(id: K, event: Events[K]): void
+  emit<K extends keyof Events>(id: K, event?: Events[K]): void
 }
 
 export * from '@'


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Types
- [x] Refactoring Code
- [x] Documentation

## Request Description

Adds new `off` method.

### .off()

Removes event listeners.

```ts
emitter.off<K>(id?: K | undefined, callback?: ((event: Events[K]) => void) | undefined): void
```

```ts
// Removes all event listeners across all event types
emitter.off()

// Removes all click listeners
emitter.off('click')

// Removes specific scroll callback
emitter.off('scroll', scrollCallback)
```

## Additional Details

Improves types and docs.

Also, adds return cleanup fn for `on` method.

### .on()

Registers an event listener for a specific event type.

Returns a cleanup function that removes the listener when called.

```ts
emitter.on<K>(id: K, callback: (event: Events[K]) => void): () => void
```

```ts
// Adds click listener
const unsubscribe = emitter.on('scroll', ({ x, y }) => {
  console.log(x, y)
})

// Removes the listener
unsubscribe()
```
