### PR TITLE
feat: add new off-callback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <pre align="center">pnpm add @hypernym/emitter</pre>
 
 <p align="center">
-  <sub>Size: <code>~0.52 KB</code> min, <code>~0.29 KB</code> gzip</sub>
+  <sub>Size: <code>~0.61 KB</code> min, <code>~0.33 KB</code> gzip</sub>
 </p>
 
 <br>
@@ -145,6 +145,9 @@ emitter.off()
 
 // Removes all click listeners
 emitter.off('click')
+
+// Removes specific callback from the `events` map without `id`
+emitter.off(undefined, callback)
 
 // Custom scroll callback
 const scrollCallback = ({ x, y }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,15 +63,24 @@ export function createEmitter<
       id?: Key,
       callback?: EventCallback<Key, Events>,
     ): void {
-      if (!id) return events.clear()
-      const map = events.get(id)
+      if (!id && !callback) return events.clear()
+      if (!id && callback) {
+        for (const [key, map] of [...events.entries()]) {
+          if (map.delete(callback as EventCallback<keyof Events, Events>)) {
+            if (!map.size) events.delete(key)
+            break
+          }
+        }
+        return
+      }
+      const map = events.get(id!)
       if (!map) return
       if (!callback) {
-        events.delete(id)
+        events.delete(id!)
         return
       }
       map.delete(callback as EventCallback<keyof Events, Events>)
-      if (!map.size) events.delete(id)
+      if (!map.size) events.delete(id!)
     },
     get<Key extends keyof Events, Options extends EventOptions = EventOptions>(
       id: Key,
@@ -90,11 +99,12 @@ export function createEmitter<
     emit<Key extends keyof Events>(id: Key, event: Events[Key]): void {
       const map = events.get(id)
       if (!map) return
+      const values = [...map.values()]
       if (typeof event === 'function') {
-        for (const details of [...map.values()]) event(details)
+        for (const details of values) event(details)
         return
       }
-      for (const { callback } of [...map.values()]) callback(event)
+      for (const { callback } of values) callback(event)
     },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,9 @@ export function createEmitter<
         for (const details of values) event(details)
         return
       }
-      for (const { callback } of values) callback(event)
+      for (const { callback } of values) {
+        ;(callback as (arg: Events[Key]) => void)(event)
+      }
     },
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,9 +14,11 @@ export type EventOptions<
 export type EventCallback<
   Key extends keyof Events,
   Events extends EventsMap,
-> = undefined extends Events[Key]
-  ? (event?: Events[Key]) => void
-  : (event: Events[Key]) => void
+> = Key extends any
+  ? undefined extends Events[Key]
+    ? (event?: Events[Key]) => void
+    : (event: Events[Key]) => void
+  : never
 
 export type EventDetails<
   Key extends keyof Events,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->

## Type of Change

<!-- Check the boxes with an 'x' that refers to your changes. -->

- [x] New feature
- [x] Documentation

## Request Description

Adds new logic to off method. 

Allows removal of `callback` without `id`.

```ts
// Removes specific callback from the `events` map without `id`
emitter.off(undefined, callback)
```